### PR TITLE
Convert static to non-static properties in BarPanel

### DIFF
--- a/src/Tracy/BarPanel.php
+++ b/src/Tracy/BarPanel.php
@@ -10,31 +10,31 @@ class BarPanel implements \Tracy\IBarPanel
      * @author Freepik.com
      * @license http://file000.flaticon.com/downloads/license/license.pdf
      */
-    public static $icon = 'data:image/svg+xml;utf8;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTYuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjE2cHgiIGhlaWdodD0iMTZweCIgdmlld0JveD0iMCAwIDk1LjEwMyA5NS4xMDMiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDk1LjEwMyA5NS4xMDM7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPGc+Cgk8ZyBpZD0iTGF5ZXJfMV8xNF8iPgoJCTxnPgoJCQk8Zz4KCQkJCTxnPgoJCQkJCTxwYXRoIGQ9Ik00Ny41NjEsMEMyNS45MjgsMCw4LjM5LDYuMzkzLDguMzksMTQuMjgzdjExLjcyYzAsNy44OTEsMTcuNTM4LDE0LjI4MiwzOS4xNzEsMTQuMjgyICAgICAgIGMyMS42MzIsMCwzOS4xNy02LjM5MiwzOS4xNy0xNC4yODJ2LTExLjcyQzg2LjczMSw2LjM5Myw2OS4xOTMsMCw0Ny41NjEsMHoiIGZpbGw9IiMyYjJiMmIiLz4KCQkJCTwvZz4KCQkJPC9nPgoJCQk8Zz4KCQkJCTxnPgoJCQkJCTxwYXRoIGQ9Ik00Ny41NjEsNDcuMTE1Yy0yMC42NTQsMC0zNy42ODItNS44MzItMzkuMTcxLTEzLjIyN2MtMC4wNzEsMC4zNTMsMCwxOS4zNTUsMCwxOS4zNTUgICAgICAgYzAsNy44OTIsMTcuNTM4LDE0LjI4MywzOS4xNzEsMTQuMjgzYzIxLjYzMiwwLDM5LjE3LTYuMzkzLDM5LjE3LTE0LjI4M2MwLDAsMC4wNDQtMTkuMDAzLTAuMDI2LTE5LjM1NSAgICAgICBDODUuMjE0LDQxLjI4NCw2OC4yMTQsNDcuMTE1LDQ3LjU2MSw0Ny4xMTV6IiBmaWxsPSIjMmIyYjJiIi8+CgkJCQk8L2c+CgkJCTwvZz4KCQkJPHBhdGggZD0iTTg2LjY5NCw2MS40NjRjLTEuNDg4LDcuMzkxLTE4LjQ3OSwxMy4yMjYtMzkuMTMzLDEzLjIyNlM5Ljg3NSw2OC44NTQsOC4zODYsNjEuNDY0TDguMzksODAuODIgICAgIGMwLDcuODkxLDE3LjUzOCwxNC4yODIsMzkuMTcxLDE0LjI4MmMyMS42MzIsMCwzOS4xNy02LjM5MywzOS4xNy0xNC4yODJMODYuNjk0LDYxLjQ2NHoiIGZpbGw9IiMyYjJiMmIiLz4KCQk8L2c+Cgk8L2c+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPC9zdmc+Cg==';
+    public $icon = 'data:image/svg+xml;utf8;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTYuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjE2cHgiIGhlaWdodD0iMTZweCIgdmlld0JveD0iMCAwIDk1LjEwMyA5NS4xMDMiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDk1LjEwMyA5NS4xMDM7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPGc+Cgk8ZyBpZD0iTGF5ZXJfMV8xNF8iPgoJCTxnPgoJCQk8Zz4KCQkJCTxnPgoJCQkJCTxwYXRoIGQ9Ik00Ny41NjEsMEMyNS45MjgsMCw4LjM5LDYuMzkzLDguMzksMTQuMjgzdjExLjcyYzAsNy44OTEsMTcuNTM4LDE0LjI4MiwzOS4xNzEsMTQuMjgyICAgICAgIGMyMS42MzIsMCwzOS4xNy02LjM5MiwzOS4xNy0xNC4yODJ2LTExLjcyQzg2LjczMSw2LjM5Myw2OS4xOTMsMCw0Ny41NjEsMHoiIGZpbGw9IiMyYjJiMmIiLz4KCQkJCTwvZz4KCQkJPC9nPgoJCQk8Zz4KCQkJCTxnPgoJCQkJCTxwYXRoIGQ9Ik00Ny41NjEsNDcuMTE1Yy0yMC42NTQsMC0zNy42ODItNS44MzItMzkuMTcxLTEzLjIyN2MtMC4wNzEsMC4zNTMsMCwxOS4zNTUsMCwxOS4zNTUgICAgICAgYzAsNy44OTIsMTcuNTM4LDE0LjI4MywzOS4xNzEsMTQuMjgzYzIxLjYzMiwwLDM5LjE3LTYuMzkzLDM5LjE3LTE0LjI4M2MwLDAsMC4wNDQtMTkuMDAzLTAuMDI2LTE5LjM1NSAgICAgICBDODUuMjE0LDQxLjI4NCw2OC4yMTQsNDcuMTE1LDQ3LjU2MSw0Ny4xMTV6IiBmaWxsPSIjMmIyYjJiIi8+CgkJCQk8L2c+CgkJCTwvZz4KCQkJPHBhdGggZD0iTTg2LjY5NCw2MS40NjRjLTEuNDg4LDcuMzkxLTE4LjQ3OSwxMy4yMjYtMzkuMTMzLDEzLjIyNlM5Ljg3NSw2OC44NTQsOC4zODYsNjEuNDY0TDguMzksODAuODIgICAgIGMwLDcuODkxLDE3LjUzOCwxNC4yODIsMzkuMTcxLDE0LjI4MmMyMS42MzIsMCwzOS4xNy02LjM5MywzOS4xNy0xNC4yODJMODYuNjk0LDYxLjQ2NHoiIGZpbGw9IiMyYjJiMmIiLz4KCQk8L2c+Cgk8L2c+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPGc+CjwvZz4KPC9zdmc+Cg==';
 
     /**
      * Title
      * @var string
      */
-    public static $title = 'PDO logger';
+    public $title = 'PDO logger';
 
     /**
      * Title HTML attributes
      * @var string
      */
-    public static $title_attributes = 'style="font-size:1.6em"';
+    public $title_attributes = 'style="font-size:1.6em"';
 
     /**
      * Time table cell HTML attributes
      * @var string
      */
-    public static $time_attributes = 'style="font-weight:bold;color:#333;font-family:Courier New;font-size:1.1em"';
-    
+    public $time_attributes = 'style="font-weight:bold;color:#333;font-family:Courier New;font-size:1.1em"';
+
     /**
      * Query table cell HTML attributes
      * @var string
      */
-    public static $query_attributes = '';
+    public $query_attributes = '';
 
     /**
      * PDO logged queries
@@ -63,7 +63,7 @@ class BarPanel implements \Tracy\IBarPanel
 	 */
     public function getTab()
     {
-        $html = '<img src="'.self::$icon.'" alt="PDO queries logger" /> ';
+        $html = '<img src="'.$this->icon.'" alt="PDO queries logger" /> ';
         $queries = count($this->queries);
         if ($queries == 0) {
             $html .= 'no queries!';
@@ -87,7 +87,7 @@ class BarPanel implements \Tracy\IBarPanel
             \SqlFormatter::$pre_attributes = 'style="color: black;"';
         }
         $queries = $this->queries;
-        $html = '<h1 '.self::$title_attributes.'>'.self::$title.'</h1>';
+        $html = '<h1 '.$this->title_attributes.'>'.$this->title.'</h1>';
         $html .= '<div class="tracy-inner tracy-InfoPanel">';
         if (count($queries) > 0) {
             $html .= '<table style="width:400px;">';
@@ -97,11 +97,11 @@ class BarPanel implements \Tracy\IBarPanel
             $html .= '</tr>';
             foreach ($queries as $query) {
                 $html .= '<tr>';
-                $html .= '<td><span '.self::$time_attributes.'>'.round($query['time'], 4).'</span></td>';
+                $html .= '<td><span '.$this->time_attributes.'>'.round($query['time'], 4).'</span></td>';
                 if (class_exists('\SqlFormatter')) {
                     $html .= '<td>'.\SqlFormatter::highlight($query['statement']).'</td>';
                 } else {
-                    $html .= '<td '.self::$query_attributes.'>'.$query['statement'].'</td>';
+                    $html .= '<td '.$this->query_attributes.'>'.$query['statement'].'</td>';
                 }
                 $html .= '</tr>';
             }


### PR DESCRIPTION
**Note:** This should be released as a 2.x version, because it will break backwards compatibility for anyone using the old static properties.

This is required to have multiple panels with different title and attributes. For example let's say I want to debug two connections to two different databases and want a different tittle and different colours for each panel so I know which is for each database. It can't be done with static properties, because the lastly-set ones will take effect when the panels are generated.

So the new usage would be:
```php
$db1Panel = new \Filisko\PDOplus\Tracy\BarPanel($db1PDOInstance);
$db1Panel->title = "DB 1 Panel";

$db2Panel = new \Filisko\PDOplus\Tracy\BarPanel($db2PDOInstance);
$db2Panel->title = "DB 2 Panel";
```