### PR TITLE
Fix type error for bool bindings

### DIFF
--- a/src/PDOStatement.php
+++ b/src/PDOStatement.php
@@ -71,7 +71,7 @@ class PDOStatement extends NativePdoStatement
         $indexed = ($bindings == array_values($bindings));
 
         foreach ($bindings as $param => $value) {
-            $value = is_numeric($value) || $value === null ? $value : $this->pdo->quote($value);
+            $value = is_numeric($value) || is_bool($value) || $value === null ? $value : $this->pdo->quote($value);
             $value = is_null($value) ? 'null' : $value;
 
             if ($indexed) {


### PR DESCRIPTION
PDO->quote only accepts string parameters.
When using a bool parameter in a query this leads to a type mismatch exception in PHP8. Bool parameters can be treated as safe like numbers.