### PR TITLE
Fix invalid fetch mode

### DIFF
--- a/src/PDO.php
+++ b/src/PDO.php
@@ -38,10 +38,10 @@ class PDO extends NativePdo
     /**
      * @inheritDoc
      */
-    public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, ...$fetch_mode_args)
+    public function query($statement, $mode = PDO::FETCH_ASSOC, ...$ctorargs )
     {
         $start = microtime(true);
-        $result = parent::query($statement, $mode, ...$fetch_mode_args);
+        $result = parent::query($statement, $mode, ...$ctorargs);
 
         $this->addLog($statement, microtime(true) - $start);
 

--- a/tests/PDOTest.php
+++ b/tests/PDOTest.php
@@ -50,7 +50,7 @@ class PDOTest extends TestCase
         $data = $stmt->fetchAll(PDO::FETCH_CLASS, "User");
         $stmt->closeCursor();
 
-        static::assertInstanceOf(PdoPlusStatement::class, $data);
+        static::assertInstanceOf(PdoPlusStatement::class, $stmt);
         static::assertEquals(
             "SELECT * FROM users WHERE `name` = 'Filis'",
             $this->sut->getLog()[1]['statement']

--- a/tests/PDOTest.php
+++ b/tests/PDOTest.php
@@ -47,7 +47,7 @@ class PDOTest extends TestCase
     public function testFetchAll()
     {
         $stmt =$this->sut->query("SELECT * FROM users WHERE `name` = 'Filis'");
-        $data = $stmt->fetchAll(PDO::FETCH_CLASS, "User");
+        $stmt->fetchAll(PDO::FETCH_CLASS, "User");
         $stmt->closeCursor();
 
         static::assertInstanceOf(PdoPlusStatement::class, $stmt);

--- a/tests/PDOTest.php
+++ b/tests/PDOTest.php
@@ -47,7 +47,7 @@ class PDOTest extends TestCase
     public function testFetchAll()
     {
         $stmt =$this->sut->query("SELECT * FROM users WHERE `name` = 'Filis'");
-        $data = $stmt->fetchAll(\PDO::FETCH_CLASS, "User");
+        $data = $stmt->fetchAll(PDO::FETCH_CLASS, "User");
         $stmt->closeCursor();
     }
 }

--- a/tests/PDOTest.php
+++ b/tests/PDOTest.php
@@ -49,6 +49,11 @@ class PDOTest extends TestCase
         $stmt =$this->sut->query("SELECT * FROM users WHERE `name` = 'Filis'");
         $data = $stmt->fetchAll(PDO::FETCH_CLASS, "User");
         $stmt->closeCursor();
+
+
+        var_dump($data);
+        var_dump($stmt);
+
     }
 }
 

--- a/tests/PDOTest.php
+++ b/tests/PDOTest.php
@@ -50,9 +50,11 @@ class PDOTest extends TestCase
         $data = $stmt->fetchAll(PDO::FETCH_CLASS, "User");
         $stmt->closeCursor();
 
-
-        var_dump($data);
-        var_dump($stmt);
+        static::assertInstanceOf(PdoPlusStatement::class, $data);
+        static::assertEquals(
+            "SELECT * FROM users WHERE `name` = 'Filis'",
+            $this->sut->getLog()[1]['statement']
+        );
 
     }
 }

--- a/tests/PDOTest.php
+++ b/tests/PDOTest.php
@@ -43,4 +43,18 @@ class PDOTest extends TestCase
             $this->sut->getLog()[1]['statement']
         );
     }
+
+    public function testFetchAll()
+    {
+        $stmt =$this->sut->query("SELECT * FROM users WHERE `name` = 'Filis'");
+        $data = $stmt->fetchAll(\PDO::FETCH_CLASS, "User");
+        $stmt->closeCursor();
+    }
+}
+
+
+class User
+{
+    public $name;
+    public $surname;
 }


### PR DESCRIPTION
Hi,

`PHP Warning: PDO::query(): SQLSTATE[HY000]: General error: mode must be an integer in ...\vendor\filisko\pdo-plus\src\PDO.php:40`

with

```
$stmt =$this->sut->query("SELECT * FROM users WHERE `name` = 'Filis'");
$data = $stmt->fetchAll(PDO::FETCH_CLASS, "User");

class User
{
    public $name;
    public $surname;
}
```

this pull request add new phpunit test and fix this problem
